### PR TITLE
Fix error when gh not present

### DIFF
--- a/rse_report_generator/gh_cli.py
+++ b/rse_report_generator/gh_cli.py
@@ -20,6 +20,6 @@ async def get_github_token() -> str | None:
     """Get the auth token being used by gh."""
     try:
         return (await _run_gh_command("auth", "token")).strip()
-    except RuntimeError as e:
-        logging.warn(str(e))
+    except Exception:
+        logging.warn("Failed to run gh command-line program")
         return None

--- a/rse_report_generator/report.py
+++ b/rse_report_generator/report.py
@@ -12,8 +12,8 @@ from githubkit import (
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from .config import PACKAGE_NAME
-from .gh_cli import get_github_token
 from .repository import Repository
+from .token import get_github_token
 
 
 async def _get_auth_strategy() -> BaseAuthStrategy:

--- a/rse_report_generator/token.py
+++ b/rse_report_generator/token.py
@@ -2,6 +2,15 @@
 
 import asyncio
 import logging
+import os
+
+_NO_TOKEN_MSG = (
+    "Could not retrieve a GitHub token from your environment. This is only an issue if "
+    "you want to access private repositories.\n\n"
+    "To use a GitHub token, either manually generate one and set the GITHUB_TOKEN "
+    "environment variable or install the GitHub command-line tools "
+    '(https://cli.github.com/) and log in with "gh auth login".\n\n'
+)
 
 
 async def _run_gh_command(*command: str) -> str:
@@ -21,5 +30,10 @@ async def get_github_token() -> str | None:
     try:
         return (await _run_gh_command("auth", "token")).strip()
     except Exception:
-        logging.warn("Failed to run gh command-line program")
-        return None
+        pass
+
+    if token := os.environ.get("GITHUB_TOKEN"):
+        return token
+
+    logging.warn(_NO_TOKEN_MSG)
+    return None


### PR DESCRIPTION
Currently the program fails if the gh command-line tool is not available, though it should not be necessary. Fix by catching errors raised by `asyncio.create_process_exec()`.

Fixes #20.

@dalonsoa Could you check this fixes things for you, please?